### PR TITLE
Fix flushing

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -18,7 +18,7 @@ $against="4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 # install using
 # npm install -g krl-compiler
-my $PARSER="krl-compiler --verify";
+my $PARSER="krl-compiler";
 my $PICO_ENGINE= $ENV{'PICO_ENGINE'} || "localhost:8080";
 
 my $allownoparse=`git config hooks.allownoparse`;


### PR DESCRIPTION
It seems that `krl-compiler --verify` doesn't output anything, but the flushing code expects it to output the rid. Removing the --verify flag fixes this issue.

(Without this change, the output looks like this:
```
Use of uninitialized value $rid_line[0] in split at .git/hooks/pre-commit line 46.
Use of uninitialized value $rid in substitution (s///) at .git/hooks/pre-commit line 48.
Use of uninitialized value $rid in concatenation (.) or string at .git/hooks/pre-commit line 57.
Use of uninitialized value $rid in print at .git/hooks/pre-commit line 60.
Flushing 
```
)